### PR TITLE
Restore original header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+// The Computer Language Benchmarks Game
+// http://benchmarksgame.alioth.debian.org/
+//
+// contributed by Cristi Cobzarenco
+
 use std::ops::{Add, Sub, Mul};
 
 const PI: f64 = 3.141592653589793;


### PR DESCRIPTION
Hello Geoffroy, thanks for your test!

I see you have already given due credit to the n-body test code in the README.md. I propose that, in addition to that, you keep the original header in the file, as in this pull request. I have nothing to do with the author; I jumped straight to the test code and thought I had seen it before but did not recall exactly where. Only then I checked your README.md more carefully.

On a side note, please add the test results of running a test with the plain rustc -O src/main.rs binary, without the intermediate steps. I would submit a pull request for those, except I can't predict the actual timings on your test environment ;-).

Best regards,
Daniel
